### PR TITLE
Add Resilience4j rate limiter

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,10 +37,16 @@ export REDIS_PORT=6379
 export WEATHER_CACHE_TTL_SECONDS=43200 # optional cache TTL
 export SERVER_PORT=8080
 export WEATHER_ALLOW_INSECURE_SSL=false # set to true if your environment lacks trusted certificates
+export WEATHER_RATE_LIMIT_FOR_PERIOD=5   # optional allowed requests per period
+export WEATHER_RATE_LIMIT_REFRESH_PERIOD=1s # optional rate limit refresh period
+export WEATHER_RATE_LIMIT_TIMEOUT=0s    # optional wait timeout when rate limited
 ```
 
 If Redis cannot be reached at runtime, the application logs a warning and still
 serves data directly from the weather service without caching.
+
+The `/api/weather` endpoint is rate limited using Resilience4j. Adjust the
+`WEATHER_RATE_LIMIT_*` environment variables to tune the limit values.
 
 Run the application using Maven:
 

--- a/pom.xml
+++ b/pom.xml
@@ -40,6 +40,11 @@
             <version>2.11.0</version>
         </dependency>
         <dependency>
+            <groupId>io.github.resilience4j</groupId>
+            <artifactId>resilience4j-spring-boot3</artifactId>
+            <version>2.2.0</version>
+        </dependency>
+        <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>

--- a/src/main/java/com/weathereye/backend/WeatherController.java
+++ b/src/main/java/com/weathereye/backend/WeatherController.java
@@ -4,6 +4,10 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.http.HttpStatus;
+import io.github.resilience4j.ratelimiter.annotation.RateLimiter;
+import io.github.resilience4j.ratelimiter.RequestNotPermitted;
 
 @RestController
 public class WeatherController {
@@ -14,11 +18,18 @@ public class WeatherController {
     }
 
     @GetMapping("/api/weather")
+    @RateLimiter(name = "weatherApi")
     public ResponseEntity<String> getWeather(@RequestParam String city) {
         String result = weatherService.getWeather(city);
         if (result == null) {
             return ResponseEntity.internalServerError().body("Failed to get weather");
         }
         return ResponseEntity.ok(result);
+    }
+
+    @ExceptionHandler(RequestNotPermitted.class)
+    public ResponseEntity<String> rateLimitExceeded() {
+        return ResponseEntity.status(HttpStatus.TOO_MANY_REQUESTS)
+                .body("Too many requests");
     }
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -8,3 +8,6 @@ server.port=${SERVER_PORT:8080}
 spring.redis.host=${REDIS_HOST:localhost}
 spring.redis.port=${REDIS_PORT:6379}
 weather.api.allowInsecureSsl=${WEATHER_ALLOW_INSECURE_SSL:false}
+resilience4j.ratelimiter.instances.weatherApi.limitForPeriod=${WEATHER_RATE_LIMIT_FOR_PERIOD:5}
+resilience4j.ratelimiter.instances.weatherApi.limitRefreshPeriod=${WEATHER_RATE_LIMIT_REFRESH_PERIOD:1s}
+resilience4j.ratelimiter.instances.weatherApi.timeoutDuration=${WEATHER_RATE_LIMIT_TIMEOUT:0s}


### PR DESCRIPTION
## Summary
- add `resilience4j-spring-boot3` dependency
- configure rate limiter defaults in `application.properties`
- annotate `/api/weather` endpoint with `@RateLimiter`
- handle `RequestNotPermitted` to return HTTP 429
- document new rate limit environment variables in README

## Testing
- `mvn -q test` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_b_685b508c76848325ae26a20ec2c01f04